### PR TITLE
Fix link to NLnet project page in encryption blog post and update Reflection link

### DIFF
--- a/_posts/2025-02-24-group-encryption.md
+++ b/_posts/2025-02-24-group-encryption.md
@@ -4,7 +4,7 @@ title: "Local-First group- and message encryption in p2panda"
 subtitle: "Insights, learnings and design from our research and implementation"
 ---
 
-With the generous support of [NLNet](https://nlnet.nl/project/p2panda-encryptions/) and a pending audit by [Radically Open Security](https://www.radicallyopensecurity.com/) we're aiming at releasing our Rust crate `p2panda-encryption` towards Spring 2025!
+With the generous support of [NLNet](https://nlnet.nl/project/P2Panda/) and a pending audit by [Radically Open Security](https://www.radicallyopensecurity.com/) we're aiming at releasing our Rust crate `p2panda-encryption` towards Spring 2025!
 
 This library will offer group encryption compatible with any data type, encoding format or transport, made for p2p applications which do not rely on constant internet connectivity. Similar to our other crates, we aim to make our implementation independent of the rest of [p2panda](https://p2panda.org) while providing optional "glue code" to integrate it in into the larger p2panda ecosystem. With this design we're adding another building block for secure and private p2p applications to our p2panda collection.
 

--- a/index.html
+++ b/index.html
@@ -57,8 +57,8 @@ layout: default
 <h2 id="projects"><a href="#projects">Projects</a></h2>
 <div class="grid">
   <section class="project">
-    <a href="https://github.com/p2panda/aardvark" target="_blank">
-      <h3>📝 Aardvark (coming mid-2025)</h3>
+    <a href="https://github.com/p2panda/reflection" target="_blank">
+      <h3>📝 Reflection (coming mid-2025)</h3>
       <p>Local-first, collaborative text editor, based on GTK and Automerge.</p>
       <p>This is a collaboration with friends from GNOME and part of a general research to explore local-first code, UI and UX patterns in GTK applications.</p>
     </a>


### PR DESCRIPTION
Noticed these things while looking at our website.